### PR TITLE
Adding Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: node --inspect ./app/app.js


### PR DESCRIPTION
### What
App keeps timing out due to not binding to the Heroku port. Changed app to be a `worker` in the `Procfile` to try and get around this

### Changes
- Added `Procfile` specifying the app as a worker