### PR TITLE
Removed sodium

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7781,15 +7781,6 @@
       "resolved": "https://registry.npmjs.org/snekfetch/-/snekfetch-3.6.4.tgz",
       "integrity": "sha512-NjxjITIj04Ffqid5lqr7XdgwM7X61c/Dns073Ly170bPQHLm6jkmelye/eglS++1nfTWktpP6Y2bFXjdPlQqdw=="
     },
-    "sodium": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/sodium/-/sodium-2.0.3.tgz",
-      "integrity": "sha512-/z1tdOf+tn+MZr6uiKno709w2V5LwqukNWxOWi6NiSBia5E7Fp33f3CUHtCIR2184DEylytXdTZNryQUQwNKkQ==",
-      "dev": true,
-      "requires": {
-        "nan": "^2.8.0"
-      }
-    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "prettier": "^1.16.4",
     "sinon": "^7.2.3",
     "sinon-chai": "^3.3.0",
-    "sodium": "^2.0.3",
     "uws": "^9.148.0"
   },
   "dependencies": {


### PR DESCRIPTION
### What
Sodium keeps failing to build, both on local and on heroku, and is being a general pain

### Changes
- Removed `sodium@2.0.3` from `package.json`